### PR TITLE
Expand shrink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,9 @@ build/Release
 # Dependency directory
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
 node_modules
+
+# editorconfig
+.editorconfig
+
+# linter
+.eslintrc

--- a/index.js
+++ b/index.js
@@ -166,6 +166,7 @@
       a.classList.add('icon');
       a.classList.add('bb-button');
       a.setAttribute('role', 'button');
+      a.setAttribute('aria-hidden', 'true');
       li.appendChild(a);
 
       return li;

--- a/index.js
+++ b/index.js
@@ -84,7 +84,11 @@
 
     initialize: function initialize() {
       this._elements = {
-        quickSettingsContainer: document.querySelector('#quick-settings > ul'),
+        quickSettingsContainer: (function () {
+          var ul = document.querySelector('#quick-settings > ul');
+          ul.cachedHeight = ul.clientHeight;
+          return ul;
+        }()),
         quickSettingsContainerExtension: (function () {
           var ul = document.createElement('ul');
           ul.id = 'quick-settings-extension';
@@ -199,12 +203,13 @@
     },
 
     _shrinkSettings: function () {
-      this._elements.utilityTrayFooter.style.transform = 'unset';
+      this._elements.utilityTrayFooter.style.transform = 'translateY(0%)';
       this._elements.utilityTrayFooter.classList.remove('open');
     },
 
     _expandSettings: function () {
-      this._elements.utilityTrayFooter.style.transform = `translateY(-${this._numberOfRows * 50 }%)`;
+      var dY = this._numberOfRows * this._elements.quickSettingsContainer.cachedHeight;
+      this._elements.utilityTrayFooter.style.transform = `translateY(-${dY}px)`;
       this._elements.utilityTrayFooter.classList.add('open');
     },
 

--- a/index.js
+++ b/index.js
@@ -147,15 +147,23 @@
         this._elements.quickSettingsContainerExtension.appendChild(btn);
       });
 
-      // change settings button per a arrow button
+      // move settings button to extra settings
       this._elements.quickSettingsContainerExtension.appendChild(this._elements.lastButton)
+
+      // change settings button per a arrow button
       var arrowButton = this.createButton('topup');
       arrowButton.firstChild.dataset.icon = 'topup';
       this._elements.quickSettingsContainer.appendChild(arrowButton);
+
+      // init arrow button
       this.initArrowButton(arrowButton);
 
       // catch events that should shrink the expanded settings
       this.initAutoShrinkSettings();
+
+      // cache the number of icon rows in extra settings to calculate
+      // how much the settings must be expanded
+      this._numberOfRows = Math.ceil(this.workingItems.length / 5);
 
       // Add additional li as placeholders to layout buttons correctly
       var fillLi = 5 - this.workingItems.length % 5;
@@ -181,7 +189,7 @@
       a.classList.add('bb-button');
       a.setAttribute('role', 'button');
 
-      // if not the elements raises an visual alarm about missing aria attribute
+      // elements raises an visual alarm about missing aria attribute
       // at least in 2.6
       a.setAttribute('aria-hidden', 'true');
 
@@ -196,7 +204,7 @@
     },
 
     _expandSettings: function () {
-      this._elements.utilityTrayFooter.style.transform = 'translateY(-100%)';
+      this._elements.utilityTrayFooter.style.transform = `translateY(-${this._numberOfRows * 50 }%)`;
       this._elements.utilityTrayFooter.classList.add('open');
     },
 

--- a/index.js
+++ b/index.js
@@ -85,7 +85,16 @@
     initialize: function initialize() {
       this._elements = {
         quickSettingsContainer: document.querySelector('#quick-settings > ul'),
-        lastButton: document.querySelector('#quick-settings-full-app').parentNode
+        quickSettingsContainerExtension: (function () {
+          var ul = document.createElement('ul');
+          ul.id = 'quick-settings-extension';
+          document.querySelector('#quick-settings').appendChild(ul);
+          return ul;
+        }()),
+        lastButton: document.querySelector('#quick-settings-full-app').parentNode,
+        utilityTrayFooter: document.querySelector('#utility-tray-footer'),
+        utilityTrayMotion: document.querySelector('#utility-tray-motion'),
+        notificationsContainer: document.querySelector('#notifications-container'),
       };
 
       this.workingItems = this.supportItems;
@@ -108,16 +117,11 @@
       };
 
       this.renderItems();
+      console.log(this);
     },
 
     renderItems: function renderItems() {
-      this._elements.quickSettingsContainer.style.flexWrap = 'wrap';
-
-      // Remove previously appended buttons if any
-      while (this._elements.lastButton.nextSibling) {
-        this._elements.quickSettingsContainer.removeChild(
-          this._elements.lastButton.nextSibling);
-      }
+      this._elements.quickSettingsContainerExtension.style.flexWrap = 'wrap';
 
       var availableItems = {
         'nfc': this.initNfcButton,
@@ -140,17 +144,27 @@
       this.workingItems.forEach((item) => {
         btn = this.createButton(item);
         availableItems[item].call(this, btn.firstChild);
-        this._elements.quickSettingsContainer.appendChild(btn);
+        this._elements.quickSettingsContainerExtension.appendChild(btn);
       });
+
+      // change settings button per a arrow button
+      this._elements.quickSettingsContainerExtension.appendChild(this._elements.lastButton)
+      var arrowButton = this.createButton('topup');
+      arrowButton.firstChild.dataset.icon = 'topup';
+      this._elements.quickSettingsContainer.appendChild(arrowButton);
+      this.initArrowButton(arrowButton);
+
+      // catch events that should shrink the expanded settings
+      this.initAutoShrinkSettings();
 
       // Add additional li as placeholders to layout buttons correctly
       var fillLi = 5 - this.workingItems.length % 5;
       for (i=0; i < fillLi; i++) {
-        this._elements.quickSettingsContainer.appendChild(
+        this._elements.quickSettingsContainerExtension.appendChild(
           document.createElement('li'));
       }
 
-      var allSettings = document.querySelectorAll('#quick-settings > ul > li');
+      var allSettings = document.querySelectorAll('#quick-settings-extension > li');
       for (var i=0; i < allSettings.length; i++) {
         allSettings[i].style.flex = '1 1 20%';
       }
@@ -166,10 +180,52 @@
       a.classList.add('icon');
       a.classList.add('bb-button');
       a.setAttribute('role', 'button');
+
+      // if not the elements raises an visual alarm about missing aria attribute
+      // at least in 2.6
       a.setAttribute('aria-hidden', 'true');
+
       li.appendChild(a);
 
       return li;
+    },
+
+    _shrinkSettings: function () {
+      this._elements.utilityTrayFooter.style.transform = 'unset';
+      this._elements.utilityTrayFooter.classList.remove('open');
+    },
+
+    _expandSettings: function () {
+      this._elements.utilityTrayFooter.style.transform = 'translateY(-100%)';
+      this._elements.utilityTrayFooter.classList.add('open');
+    },
+
+    _toggleSettings: function () {
+      if (this._elements.utilityTrayFooter.classList.contains('open')) {
+        this._shrinkSettings();
+      } else {
+        this._expandSettings();
+      }
+    },
+
+    initAutoShrinkSettings: function () {
+      // shrink when closing the utility try
+      this._elements.utilityTrayMotion.addEventListener('tray-motion-state', (event) => {
+        // if the visual effect looks weird change to closed
+        if (event.detail.value === 'closing') {
+          this._shrinkSettings();
+        }
+      }, false);
+
+      // shrink when scroll notification to make visual room
+      this._elements.notificationsContainer.addEventListener('scroll', (event) => {
+        this._shrinkSettings();
+      }, false);
+    },
+
+    initArrowButton: function initArrowButton(button) {
+      // toggle on click arrow button
+      button.addEventListener('click', this._toggleSettings.bind(this));
     },
 
     initVolumeButton: function initVolumeButton(button) {

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
   "author": "begeeben & gasolin",
   "content_scripts": [{
     "matches": "app://system.gaiamobile.org/index.html",
-    "css": [],
+    "css": ["styles.css"],
     "js": ["index.js"]
   }],
   "icons": {

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,38 @@
+#utility-tray-footer {
+  z-index: 2 !important;
+  background-color: hsl(0, 0%, 20%);
+  transition: transform 0.2s;
+  transform: translateY(0%);
+}
+
+#utility-tray-grippy {
+  z-index: 3 !important;
+}
+
+#utility-tray {
+  overflow: hidden;
+}
+
+#utility-tray-footer {
+  overflow: visible !important;
+}
+
+#quick-settings > ul > li:last-child {
+  transition: transform 0.2s;
+  transform: rotatez(0deg);
+}
+
+#utility-tray-footer.open #quick-settings > ul > li:last-child {
+  transform: rotatez(180deg);
+}
+
+#utility-tray-footer,
+#utility-tray-footer ul {
+  background-color: hsl(0, 0%, 24%);;
+}
+
+#quick-settings-extension {
+  position: absolute;
+  width: 100%;
+
+}

--- a/styles.css
+++ b/styles.css
@@ -1,38 +1,40 @@
-#utility-tray-footer {
-  z-index: 2 !important;
-  background-color: hsl(0, 0%, 20%);
-  transition: transform 0.2s;
-  transform: translateY(0%);
-}
-
-#utility-tray-grippy {
-  z-index: 3 !important;
-}
-
 #utility-tray {
   overflow: hidden;
 }
 
 #utility-tray-footer {
-  overflow: visible !important;
-}
-
-#quick-settings > ul > li:last-child {
   transition: transform 0.2s;
-  transform: rotatez(0deg);
-}
+  transform: translateY(0%);
 
-#utility-tray-footer.open #quick-settings > ul > li:last-child {
-  transform: rotatez(180deg);
-}
-
-#utility-tray-footer,
-#utility-tray-footer ul {
-  background-color: hsl(0, 0%, 24%);;
+  overflow: visible !important;
+  z-index: 2 !important;
 }
 
 #quick-settings-extension {
   position: absolute;
   width: 100%;
 
+}
+
+#utility-tray-grippy {
+  z-index: 3 !important;
+}
+
+/* We need to give a solid background because */
+/* the footer will take place over the notification */
+/* container an would be hard to read the settings */
+#utility-tray-footer,
+#utility-tray-footer ul {
+  background-color: hsl(0, 0%, 24%);;
+}
+
+
+/* spin arrow icon on open */
+#quick-settings-topup {
+  transition: transform 0.2s;
+  transform: rotatez(0deg);
+}
+
+#utility-tray-footer.open #quick-settings-topup {
+  transform: rotatez(180deg);
 }


### PR DESCRIPTION
The idea is to leave the original ul almost intact, and place the extra settings in another one. That helps to let the tray layout untouched. The new ul is placed to overflow the parent so when it's injected the layout remains the same. Also if "most used settings" is ever implemented makes sense to have separate ul.
To open the extra settings wen slide the parent element the needed distance.
I tried to calculate the distance using the height percentage an it worked, then I realized that the music widget can change the footer height, so I tried caching the height of the original ul.
I've made the settings tray opaque because now the settings slide over notifications when open.
